### PR TITLE
fix: prevent auto-scroll on pagination arrow click

### DIFF
--- a/src/components/LatestTransactions/LatestTransactions.tsx
+++ b/src/components/LatestTransactions/LatestTransactions.tsx
@@ -323,17 +323,13 @@ const LatestTransactions = ({
                     onClick={() => decreaseOffset()}
                     className={`${styles[`${theme}-left`]}`}
                   >
-                    <a href="#">
-                      <span aria-hidden="true">&#x2039;</span>
-                    </a>
+                    <span aria-hidden="true">&#x2039;</span>
                   </li>
                   <li
                     onClick={() => increaseOffset()}
                     className={`${styles[`${theme}-right`]}`}
                   >
-                    <a href="#">
-                      <span aria-hidden="true">&#x203A;</span>
-                    </a>
+                    <span aria-hidden="true">&#x203A;</span>
                   </li>
                 </ul>
               </nav>
@@ -422,9 +418,7 @@ const LatestTransactions = ({
                       onClick={() => decreaseOffset()}
                       className={`${styles[`${theme}-left`]}`}
                     >
-                      <a href="#">
-                        <span aria-hidden="true">&#x2039;</span>
-                      </a>
+                      <span aria-hidden="true">&#x2039;</span>
                     </li>
                   )}
                   {offset === 0 && (
@@ -438,9 +432,7 @@ const LatestTransactions = ({
                       onClick={() => increaseOffset()}
                       className={`${styles[`${theme}-right`]}`}
                     >
-                      <a href="#">
-                        <span aria-hidden="true">&#x203A;</span>
-                      </a>
+                      <span aria-hidden="true">&#x203A;</span>
                     </li>
                   )}
                   {queryCount <= 25 && (


### PR DESCRIPTION
# Prevent Auto-Scroll on Pagination Arrow Click

Resolves website [#109](https://github.com/sortxyz/website/issues/109)

## Summary

On click of the Chevron characters inside of each pagination "button" (actually an `<li>` tag), the data grid would navigate to its next page, but the page would also scroll all the way to the top.

The issue was only with the Chevron characters, and not the full "button".

## Changes

- Remove the unnecessary `<a href="#">` elements wrapping the Chevron character `<span>` tags.
