### PR TITLE
fix: dynamically render chain-specific URLs and currency symbols

### DIFF
--- a/__tests__/index.test.tsx
+++ b/__tests__/index.test.tsx
@@ -42,6 +42,12 @@ const blockExplorerURL: Record<string, string> = {
   goerli: 'https://goerli.etherscan.io',
 };
 
+const blockchainCurrency: Record<string, string> = {
+  ethereum: 'ETH',
+  polygon: 'MATIC',
+  goerli: 'GETH',
+};
+
 const mockFetchResponses = (responseData: any, countData: any) => {
   fetchMock
     .mockResponseOnce(JSON.stringify(responseData))
@@ -92,7 +98,10 @@ const createExpectedValues = (
       href: `${blockExplorerURL[blockchain]}/address/${record.to_address}`,
       text: record.to_address,
     },
-    { type: 'text', text: `${record.value.toString()} ETH` },
+    {
+      type: 'text',
+      text: `${record.value.toString()} ${blockchainCurrency[blockchain]}`,
+    },
   ]);
 };
 
@@ -155,8 +164,62 @@ describe('LatestTransactions', () => {
       );
     });
 
-    test('renders transaction data table headers + rows (ethereum)', async () => {
+    test('(Ethereum) renders transaction data table headers + rows', async () => {
       const blockchain = 'ethereum';
+
+      mockFetchResponses(
+        TWENTY_FIVE_TRANSACTIONS_CONTRACT_RECORDS_RESPONSE,
+        TWENTY_FIVE_TRANSACTIONS_CONTRACT_COUNT_RESPONSE,
+      );
+
+      renderComponent(blockchain, '0x1234', 'test_key');
+
+      await waitFor(() =>
+        expect(screen.getByText('Latest transactions')).toBeInTheDocument(),
+      );
+
+      HEADERS.forEach((header) => {
+        expect(screen.getByText(header)).toBeInTheDocument();
+      });
+
+      const allCells = await screen.getAllByRole('gridcell');
+      const expectedValues = createExpectedValues(
+        blockchain,
+        TWENTY_FIVE_TRANSACTIONS_CONTRACT_RECORDS_RESPONSE,
+      );
+
+      validateTransactionData(allCells, expectedValues);
+    });
+
+    test('(Polygon) renders transaction data table headers + rows', async () => {
+      const blockchain = 'polygon';
+
+      mockFetchResponses(
+        TWENTY_FIVE_TRANSACTIONS_CONTRACT_RECORDS_RESPONSE,
+        TWENTY_FIVE_TRANSACTIONS_CONTRACT_COUNT_RESPONSE,
+      );
+
+      renderComponent(blockchain, '0x1234', 'test_key');
+
+      await waitFor(() =>
+        expect(screen.getByText('Latest transactions')).toBeInTheDocument(),
+      );
+
+      HEADERS.forEach((header) => {
+        expect(screen.getByText(header)).toBeInTheDocument();
+      });
+
+      const allCells = await screen.getAllByRole('gridcell');
+      const expectedValues = createExpectedValues(
+        blockchain,
+        TWENTY_FIVE_TRANSACTIONS_CONTRACT_RECORDS_RESPONSE,
+      );
+
+      validateTransactionData(allCells, expectedValues);
+    });
+
+    test('(Goerli) renders transaction data table headers + rows', async () => {
+      const blockchain = 'goerli';
 
       mockFetchResponses(
         TWENTY_FIVE_TRANSACTIONS_CONTRACT_RECORDS_RESPONSE,

--- a/src/components/LatestTransactions/LatestTransactions.tsx
+++ b/src/components/LatestTransactions/LatestTransactions.tsx
@@ -56,6 +56,12 @@ type TransactionRow = {
   value: string;
 };
 
+const blockchainCurrency: Record<string, string> = {
+  ethereum: 'ETH',
+  polygon: 'MATIC',
+  goerli: 'GETH',
+};
+
 const LatestTransactions = ({
   contract_address,
   blockchain,
@@ -65,6 +71,12 @@ const LatestTransactions = ({
   theme = 'dark',
   enableVirtualization = true,
 }: LatestTransactionsProps) => {
+  const blockExplorerBaseURL = {
+    ethereum: 'https://etherscan.io',
+    goerli: 'https://goerli.etherscan.io',
+    polygon: 'https://polygonscan.com',
+  };
+
   const columns_val: Column<TransactionRow>[] = [
     {
       key: 'hash',
@@ -74,9 +86,7 @@ const LatestTransactions = ({
       renderCell: (props: RenderCellProps<TransactionRow>) => {
         return (
           <a
-            href={`https://${
-              blockchain === 'ethereum' ? 'etherscan' : 'polygonscan'
-            }.com/tx/${props.row.hash}`}
+            href={`${blockExplorerBaseURL[blockchain]}/tx/${props.row.hash}`}
             target="_blank"
             rel="noreferrer"
           >
@@ -129,9 +139,7 @@ const LatestTransactions = ({
       renderCell: (props: RenderCellProps<TransactionRow>) => {
         return (
           <a
-            href={`https://${
-              blockchain === 'ethereum' ? 'etherscan' : 'polygonscan'
-            }.com/address/${props.row.from}`}
+            href={`${blockExplorerBaseURL[blockchain]}/address/${props.row.from}`}
             target="_blank"
             rel="noreferrer"
           >
@@ -150,9 +158,7 @@ const LatestTransactions = ({
       renderCell: (props: RenderCellProps<TransactionRow>) => {
         return (
           <a
-            href={`https://${
-              blockchain === 'ethereum' ? 'etherscan' : 'polygonscan'
-            }.com/address/${props.row.to}`}
+            href={`${blockExplorerBaseURL[blockchain]}/address/${props.row.to}`}
             target="_blank"
             rel="noreferrer"
           >
@@ -265,7 +271,7 @@ const LatestTransactions = ({
             age: time_ago,
             from: data_row.from_address,
             to: data_row.to_address,
-            value: `${data_row.value} ETH`,
+            value: `${data_row.value} ${blockchainCurrency[blockchain]}`,
           };
           rowsTemp.push(row);
         }


### PR DESCRIPTION
# Dynamically Render Chain-Specific URLs and Currency Symbols

Resolves website [#192](https://github.com/sortxyz/website/issues/192)

## Summary

The LatestTransactions component didn't dynamically handle different blockchains.

I spotted two bugs:

1. In the "Value" column, all values had a hard-coded suffix of "ETH" appended to them, even when displaying data for other chains (Polygon, Goerli).
2. In the "Hash", "From", and "To" columns, Block Explorer URLs always pointed toward `https://etherscan.com/...` instead of being chain-specific, based on the blockchain prop.

## Changes

1. Fixed error 1
2. Fixed error 2
3. Added unit tests to verify changes